### PR TITLE
Add Polygon balances model to analyses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ logs/
 
 # Other
 .DS_Store
+.idea/

--- a/analyses/polygon_balances.sql
+++ b/analyses/polygon_balances.sql
@@ -1,0 +1,65 @@
+with filtered_traces as (
+    select
+        to_address,
+        from_address,
+        value
+    from polygon.traces
+    where status = 1
+        and (call_type not in ('delegatecall', 'callcode', 'staticcall', '') or call_type is null)
+),
+
+debits as (
+    select
+        to_address as address,
+        value
+    from filtered_traces
+    where to_address is not null
+),
+
+credits as (
+    select
+        from_address as address,
+        -1 * value as value
+    from filtered_traces
+    where from_address is not null
+),
+
+tx_fees_debits as (
+    select
+        block.timestamp as block_timestamp,
+        block.number as block_number,
+        block.miner as address,
+        sum(tx.gas * tx.gas_price) as value
+    from polygon.transactions as tx
+        inner join polygon.blocks as block on tx.block_number = block.number
+    group by
+        block.timestamp,
+        block.number,
+        block.miner
+),
+
+tx_fees_credits as (
+    select
+        block_timestamp,
+        block_number,
+        from_address as address,
+        -1 * (gas * gas_price) as value
+    from polygon.transactions
+),
+
+double_entry_ledger as (
+    select address, toInt256(value) as value from credits
+    union all
+    select address, toInt256(value) as value from debits
+    union all
+    select address, toInt256(value) as value from tx_fees_debits
+    union all
+    select address, toInt256(value) as value from tx_fees_credits
+)
+
+select
+    address,
+    sum(value) as balance
+from double_entry_ledger
+group by address
+order by balance desc


### PR DESCRIPTION
Adding the current version of the polygon balances model to the analyses/ folder to share and get initial feedback. Anything in the analyses folder will not be materialized in the warehouse so this current change has no impact on production.

I initially wrote a query that aggregated balances by block number/timestamp and then had a running sum so we could see the historical balance for any address at any block height. This query kept timing out so I reverted back to the current version of the model which is just a current state of balances.

I still believe the historical view would be much more valuable since that allows a much fuller picture. We can also still derive the current version from the historical version.

## Current Approach

![Blank diagram](https://user-images.githubusercontent.com/42483355/176676959-e10621b3-f6f0-4487-a0ca-893d8be74006.jpeg)

## Proposed Approach
![Blank diagram (1)](https://user-images.githubusercontent.com/42483355/176676988-bef888ba-6800-44c6-bdda-73902b342dba.jpeg)


