### PR TITLE
Simple cloudbuild pipeline

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,14 @@
+steps:
+
+- name: 'gcr.io/$PROJECT_ID/lua-dbt'
+  args: [
+    'run_dbt_and_update'
+  ]
+  secretEnv: ['CH_ADMIN_PASSWORD', 'SUPABASE_SQLALCHEMY_DATABASE_URI']
+
+availableSecrets:
+  secretManager:
+  - versionName: 'projects/$PROJECT_ID/secrets/CH_ADMIN_PASSWORD/versions/latest'
+    env: 'CH_ADMIN_PASSWORD'
+  - versionName: 'projects/$PROJECT_ID/secrets/SUPABASE_SQLALCHEMY_DATABASE_URI/versions/latest'
+    env: 'SUPABASE_SQLALCHEMY_DATABASE_URI'

--- a/profiles.yml
+++ b/profiles.yml
@@ -11,7 +11,7 @@ luabase:
       type: clickhouse
       schema: "{{ env_var('CH_SCHEMA') }}"
       user: "{{ env_var('CH_USER') }}"
-      password: "{{ env_var('CH_PASSWORD') }}"
+      password: "{{ env_var('CH_ADMIN_PASSWORD') }}"
       host: "{{ env_var('CH_HOST') }}"
       port: 8443
       verify: False

--- a/updateLuaSchema.py
+++ b/updateLuaSchema.py
@@ -1,0 +1,113 @@
+import os
+import json
+
+import yaml
+from clickhouse_driver import Client
+import sqlalchemy
+
+
+def updateAppData(engine, d):
+    with engine.connect() as con:
+        try:
+            sql = '''
+            UPDATE public.app_data
+            SET
+            "details" = :details,
+            "updated_on" = now()
+            WHERE data_key = :data_key
+            RETURNING data_uuid
+            '''
+            statement = sqlalchemy.sql.text(sql)
+            row = con.execute(statement, **d)
+            return {'ok': True, 'row': row.fetchone()}
+        except Exception as e:
+            print('updateAppData error: ', e)
+            return {'ok': False, 'error': e}
+
+
+def getChClient():
+    client = Client('lua-2.luabase.altinity.cloud',
+        user='admin',
+        password=os.getenv('CH_ADMIN_PASSWORD'),
+        port=9440,
+        secure=True,
+        verify=False,
+        database='default',
+        compression=True,
+        settings = {'use_numpy': True}
+    )
+    return client
+
+
+if __name__ == '__main__':
+
+    supaRaw = sqlalchemy.create_engine(os.getenv('SUPABASE_SQLALCHEMY_DATABASE_URI'))
+    rawTest = supaRaw.execute('select 1')
+    print('rawTest: ', rawTest)
+
+    client = getChClient()
+
+    sql = '''
+    select
+    `database`,
+    `table`,
+    `name`,
+    `type`,
+    `position`,
+    `default_kind`,
+    `default_expression`,
+    `is_in_partition_key`,
+    `is_in_sorting_key`,
+    `is_in_primary_key`,
+    `is_in_sampling_key`,
+    `numeric_precision`,
+    `numeric_precision_radix`,
+    `numeric_scale`,
+    `datetime_precision`,
+    `comment`
+    from system.columns
+    where `database` in (
+        'prices',
+        'ethereum',
+        'polygon',
+        'bitcoin'
+        )
+    order by `database`, `table`, `position`;
+    '''
+    df = client.query_dataframe(sql)
+    print(df.head())
+
+    # dbs = ['ethereum', 'bitcoin', 'prices'] # add solana, polygon, terra, etc.
+    print('all dbs:', df.database.unique())
+    schema = {'dbs': {}}
+    for db in df.database.unique():
+        print(f'doing db: {db}')
+        with open(f'models/{db}/schema.yml', 'r') as stream:
+            try:
+                y = yaml.safe_load(stream)
+                chCols = df[df.database == db].to_dict(orient='records')
+                for model in y['models']:
+                    for chCol in chCols:
+                        if (chCol['table'] == model['name']) or (chCol['table'] == model.get('alias', '')):
+                            for yCol in model['columns']:
+                                if yCol['name'] == chCol['name'] or yCol.get('alias', '') == chCol['name']:
+                                    yCol['ch'] = chCol
+                                    break
+                schema['dbs'][db] = y['models']
+            except yaml.YAMLError as e:
+                print(e)
+
+    print('done clickhouse pull...')
+
+
+    print(f'updating postgres... {json.dumps(schema)}')
+    updateAppData(supaRaw, {
+        'data_key': 'schema',
+        'details': json.dumps(schema)
+    })
+
+    print('done updating postgres...')
+
+    print('done.')
+
+


### PR DESCRIPTION
Following discussions on project layout, we arrived at the conclusion that the simplest deployment strategy that doesn't involve different repos and would allow us to keep standard dbt project structure is isolating deployment code in a special branch (called `deploy`). This branch will have the Dockerfile and other utilities needed for building a docker image capable of running dbt and postgres updates in our cloudbuild pipelines. Additionally this strategy saves us container space and build time, because there's no need for new images for every dbt model update.

This specific branch holds a few changes to accommodate the described strategy. Although not dbt related, it's easier to keep track of the postgres update script (`updateLuaSchema.py`) if it resides in the main branch. Also, changed environment variable from `CH_PASSWORD` to `CH_ADMIN_PASSWORD` to keep consistency with the GC secret manager. Finally added a cloudbuild file that will use the image built by the `deploy` branch to run the introduced changes.