### PR TITLE
Add Ethereum ABIs model

### DIFF
--- a/models/ethereum/abis.sql
+++ b/models/ethereum/abis.sql
@@ -1,0 +1,6 @@
+select
+    address,
+    abi,
+    JSONExtract(details, 'name', 'String') as name
+from {{ source('staging', 'ethereum_abis') }}
+where JSONExtract(details, 'public', 'Boolean') == true

--- a/models/ethereum/schema.yml
+++ b/models/ethereum/schema.yml
@@ -439,6 +439,20 @@ models:
         description: "[If available] Marketplace on which event occurred"
       - name: cost
         description: "How much the NFT was purchased for (in wei)"
+
+  - name: abis
+    description: Application binary interface (ABI) for select Ethereum contracts with contract name
+    columns:
+      - name: address
+        description: Address for contract
+        tests:
+          - unique
+          - not_null
+      - name: abi
+        description: Contract ABI (learn [more](https://www.quicknode.com/guides/solidity/what-is-an-abi))
+      - name: name
+        description: Contract name
+
 metrics:
   - name: blocks_count
     label: Blocks

--- a/models/ethereum/source.yml
+++ b/models/ethereum/source.yml
@@ -13,3 +13,8 @@ sources:
       - name: traces
       - name: transactions
       - name: name_tags2_local
+
+  - name: staging
+    description: Staged raw data
+    tables:
+      - name: ethereum_abis


### PR DESCRIPTION
**NOTE**: This PR depends on #5 being merged first

## Summary

Add a model containing the contract address, ABI, and contract name of select Ethereum contracts

## Schema

| Column | Description | Tests |
|---|---|---|
| `address` | Contract address | N, U |
| `abi` | Contract ABI | |
|`name` | Contract name | |

## QA

See example model at `ethereum_test.abis`