### PR TITLE
Specify `prod` profile target for CI pipeline runs

### DIFF
--- a/lua_dbt.sh
+++ b/lua_dbt.sh
@@ -9,9 +9,9 @@ clone () {
 run_dbt () {
     if [[ "$1" == "test" ]]
     then
-        dbt run --profiles-dir=. --profile luabase --select path:models/test
+        dbt build --profiles-dir=. --profile luabase --target prod
     else
-        dbt run --profiles-dir=. --profile luabase
+        dbt run --profiles-dir=. --profile luabase --target prod
     fi
 }
 


### PR DESCRIPTION
Specify to use the `prod` profile target. This ensures that the views are created in non-test databases.

This also uses `dbt build` for runs where "test" is specified. This is preferred over a "run-then-test" strategy in dbt.